### PR TITLE
Add Metasploitable2(Linux) under Vulnerable OS category

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Vulnerable Web Application
 * [OWASP Broken Web Applications Project](https://github.com/chuckfw/owaspbwa/)
 * [Damn Small Vulnerable Web](https://github.com/stamparm/DSVW)
 
+Vulnerable OS
+--
+* [Metasploitable2 (Linux)](https://sourceforge.net/projects/metasploitable/files/Metasploitable2/)
+
 Exploit 
 --
 * [Exploit Database](https://www.exploit-db.com/)


### PR DESCRIPTION
Add Metasploitable2 under Vulnerable OS category.

> This is Metasploitable2 (Linux)
> 
> Metasploitable is an intentionally vulnerable Linux virtual machine. This VM can be used to conduct security training, test security tools, and practice common penetration testing techniques. 
> 
> The default login and password is msfadmin:msfadmin. 
> 
> Never expose this VM to an untrusted network (use NAT or Host-only mode if you have any questions what that means). 
> 
> To contact the developers, please send email to msfdev@metasploit.com
> 
> For more information please see the following URL:
> 
> https://community.rapid7.com/docs/DOC-1875