### PR TITLE
Add NullSec Linux to penetration testing OS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Name    |    Description
 [Bugtraq](http://bugtraq-team.com/) | advanced GNU Linux pen-testing technology
 [Docker for pentest](https://github.com/aaaguirrep/pentest) | Image with the more used tools to create a pentest environment easily and quickly.
 [Kali](http://kali.org/) | the infamous pentesting distro from the folks at Offensive Security
+[NullSec Linux](https://github.com/bad-antics/nullsec-linux) | Debian-based security distro for hardware hacking with Flipper Zero, WiFi Pineapple, USB Rubber Ducky integration
 [LionSec Linux](https://lionsec-linux.org/) | pentesting OS based on Ubuntu
 [Parrot ](https://www.parrotsec.org/) | Debian includes full portable lab for security, DFIR, and development
 [Pentoo](https://www.pentoo.ch/) | pentesting OS based on Gentoo


### PR DESCRIPTION
## Addition

Adding **NullSec Linux** to the Linux Penetration Testing OS section.

### What is NullSec Linux?

A comprehensive security distribution featuring:
- **135+ specialized security tools**
- **5 specialized editions**: Standard, Cloud Pentest, AI/ML Security, Hardware Hacking, Automotive Security
- **4 architectures**: AMD64, ARM64, RISC-V, Apple Silicon (Asahi)
- **Specialized tool suites**: Cloud (AWS/GCP/Azure/K8s), AI/ML red teaming, hardware hacking (SDR/RFID/CAN), automotive security

### Repository
https://github.com/bad-antics/nullsec-linux

This fits well alongside other penetration testing distributions like Kali, Parrot, and BlackArch.