### PR TITLE
Add ReconX to Network Scanning / Reconnaissance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Name    |    Description
 ----    |    ----
 [Foot Printing with WhoIS/DNS records](https://www.sans.org/reading-room/whitepapers/hackers/fundamentals-computer-hacking-956) | a white paper from SANS
 [Google Dorks/Google Hacking](https://d4msec.wordpress.com/2015/09/03/google-dorks-for-finding-emails-admin-users-etc/) | list of commands for google hacks, unleash the power of the world's biggest search engine
+[ReconX](https://github.com/ofri09bs/reconx) | A lightweight, multithreaded network reconnaissance framework and scanner written in C with an interactive CLI.
 
 ### Vulnerable Web Application
 Name    |    Description

--- a/tools.md
+++ b/tools.md
@@ -105,6 +105,7 @@ Name | Description
 Name | Description
 ---- | ----
 [NMAP](https://nmap.org/) | The industry standard in network/port scanning.  Widely used.
+[ReconX](https://github.com/ofri09bs/reconx) | A lightweight, multithreaded network reconnaissance framework and scanner written in C with an interactive CLI.
 [Wireshark](https://www.wireshark.org/) | A versatile and feature-packed packet sniffing/analysis tool.  
 
 ### Source Code Analysis Tools


### PR DESCRIPTION
Hi! I'd like to submit ReconX to the list.

While playing CTFs and doing lab boxes, I got tired of juggling multiple terminals for Nmap, Gobuster, and custom scripts just to get initial recon done. To solve this, I built an all-in-one network reconnaissance utility in C.

It features a Metasploit-inspired interactive CLI that unifies a multithreaded port scanner (with SYN support), directory buster, ping sweeper, DNS/crt.sh enumerator, LAN sniffer, and ARP poisoner into one tool. It also automatically saves scan history to a local SQLite database.

I've made sure to update both README.md and tools.md and placed it in strict alphabetical order as per the contribution guidelines. Let me know if you need me to adjust anything in the PR. Thanks for maintaining this awesome resource!