### PR TITLE
Add CVE PoC Search to the exploits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Name    |   Description
 [0day.today](http://0day.today/) | Easy to navigate database of exploits
 [Exploit Database](https://www.exploit-db.com/) | database of a wide variety exploits, CVE compliant archive
 [CXsecurity](https://cxsecurity.com/exploit/) | Indie cybersecurity info managed by 1 person
+[CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) | Search public GitHub proof-of-concept repositories by CVE identifier, with 30,000+ CVEs indexed and updated daily.
 [Snyk Vulnerability DB](https://snyk.io/vuln/) | detailed info and remediation guidance for known vulns, also allows you to test your code
 
 


### PR DESCRIPTION
## Summary
- add CVE PoC Search to the exploit resources section
- preserve the current Markdown table format

Tool link: https://labs.jamessawyer.co.uk/cves/